### PR TITLE
fix for NRE 

### DIFF
--- a/Plugin/SSTUTools/KSPShaderTools/Addon/TexturesUnlimitedDebug.cs
+++ b/Plugin/SSTUTools/KSPShaderTools/Addon/TexturesUnlimitedDebug.cs
@@ -36,7 +36,10 @@ namespace KSPShaderTools.Addon
             }
             else//button not null, but not debug mode; needs to be removed
             {
-                ApplicationLauncher.Instance.RemoveModApplication(debugAppButton);
+                if (debugAppButton != null)
+                {
+                    ApplicationLauncher.Instance.RemoveModApplication(debugAppButton);
+                }
             }
         }
 


### PR DESCRIPTION
The old code could lead to a null reference exception if `debugAppButton = null`  and `debug = false` .

I think this would fix issue #98 . 